### PR TITLE
Set New Tab to Homepage

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,5 +15,8 @@
   ],
   "chrome_url_overrides": {
     "newtab": "index.html"
+  },
+  "chrome_settings_overrides": {
+    "homepage": "index.html"
   }
 }


### PR DESCRIPTION
Currently the New Tab page only shows up on the second "New Tab" opened not the initial tab created when opening a new window, this sets the "homepage" to the new-tab extension as well so it shows up when a new window is opened.