### PR TITLE
Minor fixes for modular UI

### DIFF
--- a/src/components/site.js
+++ b/src/components/site.js
@@ -22,10 +22,10 @@ export default {
       <div id="img" layout="row center size:6 ::color:gray-900 ::font:label-xl">
         ${site.favicon
           ? html`<img src="${site.favicon}" layout="block size:4" />`
-          : site.title.slice(0, 1).toUpperCase()}
+          : site.name.slice(0, 1).toUpperCase()}
       </div>
       <span layout="block:center self:stretch ::font:body-s">
-        ${site.title}
+        ${site.name}
       </span>
     </template>
   `.css`

--- a/src/components/tooltip.js
+++ b/src/components/tooltip.js
@@ -16,7 +16,7 @@ const timeouts = new WeakMap();
 let activeTooltip = null;
 
 export default {
-  autohide: 2,
+  autohide: 5,
   wrap: false,
   position: 'top', // top, bottom
   show: {

--- a/src/stores/site.js
+++ b/src/stores/site.js
@@ -16,6 +16,7 @@ export default {
   title: '',
   url: '',
   favicon: '',
+  name: (site) => site.title || new URL(site.url).hostname,
   [store.connect]: {
     async list(type) {
       switch (type) {
@@ -33,7 +34,9 @@ export default {
             })),
           ].filter(({ url }) => !userTopSites.some((s) => s.url === url));
 
-          return [...userTopSites, ...newtabSites].slice(0, 8);
+          return [...userTopSites, ...newtabSites]
+            .slice(0, 8)
+            .filter(({ url }) => url);
         }
         default:
           throw Error(`Unknown site list type: ${type}`);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -118,6 +118,7 @@ html {
   --font-body-xs: 12px / 18px var(--font-family-body);
 
   --text-transform-uppercase: uppercase;
+  --scrollbar-width-none: none;
 
   min-height: 100%;
   -moz-osx-font-smoothing: grayscale;

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -15,6 +15,7 @@ import Article from '../stores/article.js';
 import Settings from '../stores/settings.js';
 import Site from '../stores/site.js';
 import Stats from '../stores/stats.js';
+import User from '../stores/user.js';
 
 import Sidebar from './sidebar.js';
 
@@ -23,8 +24,9 @@ export default {
   articles: store([Article]),
   settings: store(Settings),
   stats: store(Stats),
+  user: store(User),
   topSites: () => store.get([Site], 'top'),
-  content: ({ articles, settings, stats, topSites }) =>
+  content: ({ articles, settings, stats, topSites, user }) =>
     store.ready(settings)
       ? html`
           <template layout="column gap:4" layout@768px="gap:5">
@@ -64,7 +66,7 @@ export default {
             ${settings.sites &&
             html`
               <div
-                layout="row gap:0.5 overflow:x:scroll basis:auto margin:-1:-2:-2 padding:1:1.5:2"
+                layout="row gap:0.5 overflow:x:auto basis:auto margin:-1:-2:-2 padding:1:1.5:2 ::scrollbar-width:none"
                 layout@768px="gap:3 padding:1:4.5:2"
               >
                 <div layout="grow shrink"></div>
@@ -121,20 +123,23 @@ export default {
                     <gh-button>Show previous editions</gh-button>
                   </gh-action>
                 </div>
-                <gh-box layout="column gap:2" layout@768px="row items:center">
-                  <div layout="column gap:0.5 grow">
-                    <h3 layout="::font:display-l ::text-transform:uppercase">
-                      Join Ghostery's Privacy Digest
-                    </h3>
-                    <p layout="::font:body-xl">
-                      Receive the latest privacy news & tips, straight to your
-                      inbox. Every two weeks.
-                    </p>
-                  </div>
-                  <gh-action href="https://www.ghostery.com/privacy-digest">
-                    <gh-button>Subscribe</gh-button>
-                  </gh-action>
-                </gh-box>
+                ${store.error(user) &&
+                html`
+                  <gh-box layout="column gap:2" layout@768px="row items:center">
+                    <div layout="column gap:0.5 grow">
+                      <h3 layout="::font:display-l ::text-transform:uppercase">
+                        Join Ghostery's Privacy Digest
+                      </h3>
+                      <p layout="::font:body-xl">
+                        Receive the latest privacy news & tips, straight to your
+                        inbox. Every two weeks.
+                      </p>
+                    </div>
+                    <gh-action href="https://www.ghostery.com/privacy-digest">
+                      <gh-button>Subscribe</gh-button>
+                    </gh-action>
+                  </gh-box>
+                `}
               </section>
             `}
           </template>


### PR DESCRIPTION
Fixes #26 

* Expands tooltip autohide to 5 seconds
* Adds fallback to URL hostname when the title of the site is missing
* Hides horizontal scrollbar in the top sites section
* Hides "Join Ghostery's Privacy Digest" section for logged-in users - for now, there is no better way to handle it, as user data does not contain information if the user disallowed newsletter on sign-up

Build:
[ghostery_new_tab-1.0.0.zip](https://github.com/ghostery/ghostery-newtab-extension/files/13389529/ghostery_new_tab-1.0.0.zip)
