### PR TITLE
Fix Firefox bug - anchors are unfocusable when used in Shadow DOM

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,11 @@ const WEB_EXT_TARGETS = {
 const watch = process.argv.includes('--watch');
 const target = process.argv[watch ? 3 : 2] || 'ghostery';
 
+if (!WEB_EXT_TARGETS[target]) {
+  console.error('Specified target is not supported: ', target);
+  process.exit(1);
+}
+
 function WebExtPlugin() {
   let childProcess = null;
 
@@ -25,10 +30,12 @@ function WebExtPlugin() {
           'run',
           'web-ext',
           '--',
-          `--target=${WEB_EXT_TARGETS[target]}`,
-          target === 'ghostery'
-            ? '--firefox="/Applications/Ghostery Private Browser.app/Contents/MacOS/Ghostery"'
-            : '',
+          ...(target === 'ghostery'
+            ? [
+                '--target=firefox-desktop',
+                '--firefox="/Applications/Ghostery Private Browser.app/Contents/MacOS/Ghostery"',
+              ]
+            : [`--target=${WEB_EXT_TARGETS[target]}`]),
         ]);
 
         // pass data to console

--- a/src/components/action.js
+++ b/src/components/action.js
@@ -12,7 +12,29 @@
 import { html } from 'hybrids';
 
 export default {
-  href: '',
+  href: {
+    value: '',
+    ...(__PLATFORM__ !== 'chrome'
+      ? {
+          connect(host, key) {
+            if (host[key]) {
+              host.tabIndex = 0;
+
+              const cb = (e) => {
+                if (e.key === 'Enter') {
+                  host.render().querySelector('a').click();
+                }
+              };
+              host.addEventListener('keydown', cb);
+
+              return () => {
+                host.removeEventListener('keydown', cb);
+              };
+            }
+          },
+        }
+      : {}),
+  },
   render: ({ href }) => html`
     <template layout="block">
       ${href


### PR DESCRIPTION
* Minor fix in build script
* Monkey patch for a bug in Firefox engine, where `<a>` elements are not focusable when used inside of the Shadow DOM